### PR TITLE
Fixed typo in ypbindpkg

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 #Install ypbind
-- name: Ensure {{ ypbind_pkg }} is installed
+- name: Ensure {{ ypbindpkg }} is installed
   yum: 
-    name: '{{ ypbind_pkg }}'
+    name: '{{ ypbindpkg }}'
     state: 'latest'
 
 #Configure yp.conf


### PR DESCRIPTION
Fixed a typo in ypbindpkg, that cased the full ansible repo to break